### PR TITLE
Remove type from enforce in checkValid alias

### DIFF
--- a/source/daffodil/bmp/package.d
+++ b/source/daffodil/bmp/package.d
@@ -99,7 +99,7 @@ BmpMetaData loadMeta(R)(R data) if (isInputRange!R &&
     }
 
     // Validation
-    alias checkValid = enforce!(InvalidHeader, bool);
+    alias checkValid = enforce!InvalidHeader;
 
     checkValid(dibVersion > DibVersion.CORE || dibHeader.bitCount < 16,
                "Old BMP image header does not support bpp > 8");


### PR DESCRIPTION
`enforce` was turned into an eponymous template in phobos 2.079 (https://github.com/dlang/phobos/commit/611e62c96f510b117de9d56279fa7ef9c87e56ad), making daffodil fail to build:
```
source/daffodil/bmp/package.d(102,24): Error: template `std.exception.enforce` does not match any template declaration
source/daffodil/bmp/package.d(31,10): Error: template instance `daffodil.bmp.loadMeta!(InputRange!ubyte)` error instantiating
```
Remove `bool` to make it build successfully again.